### PR TITLE
fix compiler incompatibility issue - downgrade Microsoft.CodeAnalysis.CSharp to 4.5.0

### DIFF
--- a/Raffinert.AccessGenerator.Core/GeneratorHelper.cs
+++ b/Raffinert.AccessGenerator.Core/GeneratorHelper.cs
@@ -87,8 +87,7 @@ public static class GeneratorHelper
 			return new GenerationContext(ImmutableArray<ResourceItem>.Empty, rootNamespace ?? "EmptyRootNamespace");
 		}
 
-		return new GenerationContext([
-			..pathAndKinds.Select(pathAndKind =>
+		return new GenerationContext(pathAndKinds.Select(pathAndKind =>
 			{
 				string resourcePath = Utils.GetRelativePath(pathAndKind.Path, buildProjectDir).Replace("%20", " ");
 				string resourceName = Utils.GetResourceName(resourcePath);
@@ -96,7 +95,6 @@ public static class GeneratorHelper
 				// trick to skip testhost.exe and testhost.dll and other files that are external to the solution
 				var kind = pathAndKind.Path.IsSubPathOf(buildProjectDir) ? pathAndKind.Kind : ResourceKind.Unspecified;
 				return new ResourceItem(resourcePath, identifierName, resourceName, kind);
-			})
-		], rootNamespace);
+			}).ToImmutableArray(), rootNamespace);
 	}
 }

--- a/Raffinert.ContentItemAccessGenerator/Raffinert.ContentItemAccessGenerator.csproj
+++ b/Raffinert.ContentItemAccessGenerator/Raffinert.ContentItemAccessGenerator.csproj
@@ -7,13 +7,14 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Authors>Christoph Hornung, Yevhen Cherkes</Authors>
 		<PackageId>Raffinert.ContentItemAccessGenerator</PackageId>
-		<Version>1.0.6</Version>
+		<Version>1.0.7</Version>
 		<Copyright>Christoph Hornung, Yevhen Cherkes</Copyright>
 		<Description>Generates strongly typed access methods for content items.</Description>
 		<PackageProjectUrl>https://github.com/Raffinert/AssetAccessGenerator</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Raffinert/AssetAccessGenerator</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageReleaseNotes>
+			v 1.0.7 - Downgrade version of Microsoft.CodeAnalysis.CSharp to be compatible with entityframework design tools.
 			v 1.0.6 - Add GetFileInfo extension.
 			v 1.0.5 - Fix missing using System.Threading directive.
 			v 1.0.4 - Fix missing using System.Threading.Tasks directive.
@@ -61,7 +62,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Raffinert.EmbeddedResourceAccessGenerator/Raffinert.EmbeddedResourceAccessGenerator.csproj
+++ b/Raffinert.EmbeddedResourceAccessGenerator/Raffinert.EmbeddedResourceAccessGenerator.csproj
@@ -7,13 +7,14 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Authors>Christoph Hornung, Yevhen Cherkes</Authors>
 		<PackageId>Raffinert.EmbeddedResourceAccessGenerator</PackageId>
-		<Version>1.0.4</Version>
+		<Version>1.0.5</Version>
 		<Copyright>Christoph Hornung, Yevhen Cherkes</Copyright>
 		<Description>Generates strongly typed access methods for embedded resources.</Description>
 		<PackageProjectUrl>https://github.com/Raffinert/AssetAccessGenerator</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Raffinert/AssetAccessGenerator</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageReleaseNotes>
+			v 1.0.5 - Downgrade version of Microsoft.CodeAnalysis.CSharp to be compatible with entityframework design tools.
 			v 1.0.4 - Fix missing using System.Threading directive.
 			v 1.0.3 - Fix missing using System.Threading.Tasks directive.
 			v 1.0.2 - Separate readmes between the projects and update them.
@@ -63,7 +64,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Raffinert.NoneItemAccessGenerator/Raffinert.NoneItemAccessGenerator.csproj
+++ b/Raffinert.NoneItemAccessGenerator/Raffinert.NoneItemAccessGenerator.csproj
@@ -7,13 +7,14 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Authors>Christoph Hornung, Yevhen Cherkes</Authors>
 		<PackageId>Raffinert.NoneItemAccessGenerator</PackageId>
-		<Version>1.0.6</Version>
+		<Version>1.0.7</Version>
 		<Copyright>Christoph Hornung, Yevhen Cherkes</Copyright>
 		<Description>Generates strongly typed access methods for none item files.</Description>
 		<PackageProjectUrl>https://github.com/Raffinert/AssetAccessGenerator</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Raffinert/AssetAccessGenerator</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageReleaseNotes>
+			v 1.0.7 - Downgrade version of Microsoft.CodeAnalysis.CSharp to be compatible with entityframework design tools.
 			v 1.0.6 - Add GetFileInfo extension.
 			v 1.0.5 - Fix missing using System.Threading directive.
 			v 1.0.4 - Fix missing using System.Threading.Tasks directive.
@@ -61,7 +62,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
fix compiler incompatibility issue between Microsoft.EntityFrameworkCore.Tools Version="8.0.11" which requires exact version Microsoft.CodeAnalysis.CSharp Version="4.5.0"